### PR TITLE
Change YAML name format

### DIFF
--- a/config/gamification.yml
+++ b/config/gamification.yml
@@ -52,7 +52,8 @@ achievements:
 
     CommunicatorSilver:
         requirements:
-            - achievement: CommunicatorBronze
+            - achievement:
+                name: CommunicatorBronze
             - xp: postXP
               amount: ">= 5"
         replaces: [CommunicatorBronze]
@@ -88,7 +89,7 @@ achievements:
                       value: java
         scope: [user]
 
-    # achievement per comleted course
+    # achievement per completed course
     CourseCompletedAward:
         requirements:
             - event:

--- a/config/gamification.yml
+++ b/config/gamification.yml
@@ -7,19 +7,23 @@ XPs:
 events:
     ForumPost:
         actions:
-            - xp: postXP
-              amount: 1
-            - xp: XP
-              amount: 10
+            - xp:
+                name: postXP
+                amount: 1
+            - xp:
+                name: XP
+                amount: 10
     QuestionAsked:
         actions:
-            - xp: XP
-              amount: 2
+            - xp:
+                name: XP
+                amount: 2
     VoluntarySelfTestTaken: ~
     CourseCompleted:
         actions:
-            - xp: XP
-              amount: 20
+            - xp:
+                name: XP
+                amount: 20
     VideoClicked: ~
     SelfAssigmentStarted: ~
     SelfTestStarted: ~
@@ -43,19 +47,22 @@ achievements:
 
     CommunicatorBronze:
         requirements:
-            - xp: postXP
-              amount: 2
+            - xp:
+                name: postXP
+                amount: 2
         actions:
-            - xp: XP
-              amount: 23
+            - xp:
+                name: XP
+                amount: 23
         hidden: true
 
     CommunicatorSilver:
         requirements:
             - achievement:
                 name: CommunicatorBronze
-            - xp: postXP
-              amount: ">= 5"
+            - xp:
+                name: postXP
+                amount: ">= 5"
         replaces: [CommunicatorBronze]
 
     ComCom:
@@ -76,8 +83,9 @@ achievements:
         # could be e.g. per user and course, could be renamed to "per"
         scope: [user]
         actions:
-            - xp: XP
-              amount: 2
+            - xp:
+                name: XP
+                amount: 2
 
     JavaPro:
         requirements:
@@ -112,15 +120,16 @@ achievements:
         hidden: true
         scope: [user, context.course_id, context.course_week]
         actions:
-            - xp: XP
-              amount: 10
-              requirements:
-                - achievement:
-                    name: ContinousAttendance
-                    conditions:
-                        - parameter: context.user_id
-                          value: user_id
-                        - parameter: context.course_week
-                          value: course_week -1
-                        - parameter: context.course_id
-                          value: course_id
+            - xp:
+                name: XP
+                amount: 10
+                requirements:
+                  - achievement:
+                      name: ContinousAttendance
+                      conditions:
+                          - parameter: context.user_id
+                            value: user_id
+                          - parameter: context.course_week
+                            value: course_week -1
+                          - parameter: context.course_id
+                            value: course_id

--- a/docs/yaml_general.yml
+++ b/docs/yaml_general.yml
@@ -14,8 +14,9 @@ achievements:
     YourAchievement:
         requirements:
             # implicit AND semantic
-            - achievement: YourOtherAchievement
-              amount: 1
+            - achievement:
+                name: YourOtherAchievement
+                amount: 1
             - xp: yourXP
               amount: >= 10
             - event:

--- a/docs/yaml_general.yml
+++ b/docs/yaml_general.yml
@@ -6,8 +6,9 @@ XPs:
 events:
     YourEventName:
         actions:
-            - xp: yourXP
-              amount: 1
+            - xp:
+                name: yourXP
+                amount: 1
     YourEventWithoutAction: ~
 
 achievements:
@@ -17,8 +18,9 @@ achievements:
             - achievement:
                 name: YourOtherAchievement
                 amount: 1
-            - xp: yourXP
-              amount: >= 10
+            - xp:
+                name: yourXP
+                amount: >= 10
             - event:
                 name: YourEventName
                 # amount is implicitly 1
@@ -39,10 +41,12 @@ achievements:
                             - parameter: someOtherParameter
                               value: 100
             - AnyOf:
-                - xp: yourXP
-                  amount: >= 10
-                - xp: XP
-                  amount: >= 10
+                - xp:
+                    name: yourXP
+                    amount: >= 10
+                - xp:
+                    name: XP
+                    amount: >= 10
         replaces: [YourOtherAchievement]
         # maxAwarded is implicitly 1
         maxAwarded: 2
@@ -50,7 +54,8 @@ achievements:
         scope: [context.course_id]
         # actions that are executed when achievement is awarded
         actions:
-            - xp: XP
-              amount: 100
+            - xp:
+                name: XP
+                amount: 100
         # implicitly false
         hidden: true

--- a/src/hooks/achievement-actions.js
+++ b/src/hooks/achievement-actions.js
@@ -17,14 +17,14 @@ module.exports = function (options = {}) {
         const uniqueCombination = await xpService.find({
           query: {
             user_id: context.data.user_id,
-            name: action['xp']
+            name: action['xp']['name']
           }
         });
 
         if (uniqueCombination.length > 0) {
-          await xpService.patch(uniqueCombination[0]._id, {amount: uniqueCombination[0].amount + action['amount']});
+          await xpService.patch(uniqueCombination[0]._id, {amount: uniqueCombination[0].amount + action['xp']['amount']});
         } else {
-          await xpService.create({user_id: context.data.user_id, name: action['xp'], amount: action['amount']});
+          await xpService.create({user_id: context.data.user_id, name: action['xp']['name'], amount: action['xp']['amount']});
         }
       }
     }

--- a/src/hooks/event-actions.js
+++ b/src/hooks/event-actions.js
@@ -18,14 +18,14 @@ module.exports = function (options = {}) {
         const uniqueCombination = await xpService.find({
           query: {
             user_id: context.data.user_id,
-            name: action['xp']
+            name: action['xp']['name']
           }
         });
 
         if (uniqueCombination.length > 0) {
-          await xpService.patch(uniqueCombination[0]._id, {amount: uniqueCombination[0].amount + action['amount']});
+          await xpService.patch(uniqueCombination[0]._id, {amount: uniqueCombination[0].amount + action['xp']['amount']});
         } else {
-          await xpService.create({user_id: context.data.user_id, name: action['xp'], amount: action['amount']});
+          await xpService.create({user_id: context.data.user_id, name: action['xp']['name'], amount: action['xp']['amount']});
         }
       }
     }

--- a/src/rule-parser.js
+++ b/src/rule-parser.js
@@ -42,7 +42,7 @@ class Requirement {
 
   static fromYamlRequirement(requirement) {
     if (requirement['achievement'] !== undefined) {
-      return new AchievementRequirement(requirement);
+      return new AchievementRequirement(requirement['achievement']);
     }
     if (requirement['xp'] !== undefined) {
       return new XPRequirement(requirement);
@@ -117,7 +117,7 @@ class AchievementRequirement extends Requirement {
     const matches = await context.app.service('achievements').find({
       query: {
         user_id: context.data.user_id,
-        name: this.requirement['achievement']
+        name: this.requirement['name']
       }
     });
     if (matches.length === 0) return false;

--- a/src/rule-parser.js
+++ b/src/rule-parser.js
@@ -45,7 +45,7 @@ class Requirement {
       return new AchievementRequirement(requirement['achievement']);
     }
     if (requirement['xp'] !== undefined) {
-      return new XPRequirement(requirement);
+      return new XPRequirement(requirement['xp']);
     }
     if (requirement['event'] !== undefined) {
       return new EventRequirement(requirement['event']);
@@ -96,7 +96,7 @@ class XPRequirement extends Requirement {
     const matches = await context.app.service('xp').find({
       query: {
         user_id: context.data.user_id,
-        name: this.requirement['xp']
+        name: this.requirement['name']
       }
     });
     if (matches.length === 0) return false;

--- a/test/config/achievement-rule-checker-config.yml
+++ b/test/config/achievement-rule-checker-config.yml
@@ -5,7 +5,7 @@ events:
     EventGiving10XP:
         actions:
             - xp: XP
-              amount: 10 
+              amount: 10
     EventGiving2XPTypes:
         actions:
             - xp: XP
@@ -17,7 +17,8 @@ events:
 achievements:
     ChainedAchievement:
       requirements:
-        - achievement: 10XPAchievement
+        - achievement:
+            name: 10XPAchievement
     10XPAchievement:
         requirements:
             - xp: XP
@@ -34,7 +35,8 @@ achievements:
               amount: 10
     AchievementRequiringOtherAchievement:
         requirements:
-            - achievement: AchievementBeingRequired
+            - achievement:
+                name: AchievementBeingRequired
     AchievementRequiringEvent:
         requirements:
             - event:

--- a/test/config/achievement-rule-checker-config.yml
+++ b/test/config/achievement-rule-checker-config.yml
@@ -4,14 +4,17 @@ XPS:
 events:
     EventGiving10XP:
         actions:
-            - xp: XP
-              amount: 10
+            - xp:
+                name: XP
+                amount: 10
     EventGiving2XPTypes:
         actions:
-            - xp: XP
-              amount: 10
-            - xp: secondXPType
-              amount: 10
+            - xp:
+                name: XP
+                amount: 10
+            - xp:
+                name: secondXPType
+                amount: 10
     EventGrantingAchievement: ~
 
 achievements:
@@ -21,18 +24,22 @@ achievements:
             name: 10XPAchievement
     10XPAchievement:
         requirements:
-            - xp: XP
-              amount: 10
+            - xp:
+                name: XP
+                amount: 10
     AchievementRequiring2XPTypes:
         requirements:
-            - xp: XP
-              amount: 10
-            - xp: secondXPType
-              amount: 10
+            - xp:
+                name: XP
+                amount: 10
+            - xp:
+                name: secondXPType
+                amount: 10
     AchievementBeingRequired:
         requirements:
-            - xp: XP
-              amount: 10
+            - xp:
+                name: XP
+                amount: 10
     AchievementRequiringOtherAchievement:
         requirements:
             - achievement:
@@ -44,23 +51,28 @@ achievements:
     AnyOfAchievement:
         requirements:
             - AnyOf:
-                - xp: XP
-                  amount: 10
-                - xp: secondXPType
-                  amount: 10
+                - xp:
+                    name: XP
+                    amount: 10
+                - xp:
+                    name: secondXPType
+                    amount: 10
     AchievementReplacingOther:
         requirements:
-            - xp: XP
-              amount: 20
+            - xp:
+                name: XP
+                amount: 20
         replaces: [AchievementBeingReplaced]
     AchievementBeingReplaced:
         requirements:
-            - xp: XP
-              amount: 10
+            - xp:
+                name: XP
+                amount: 10
     AchievementCanBeAwardedTwiceAtOnce:
         requirements:
-            - xp: XP
-              amount: 10
+            - xp:
+                name: XP
+                amount: 10
         maxAwarded: 2
     AchievementCanBeAwardedTwice:
             requirements:

--- a/test/config/after-achievement-module-config.yml
+++ b/test/config/after-achievement-module-config.yml
@@ -4,14 +4,17 @@ XPS:
 events:
     EventGiving10XP:
         actions:
-            - xp: XP
-              amount: 10 
+            - xp:
+                name: XP
+                amount: 10
 
 achievements:
     AchievementGiving10XP:
         requirements:
-            - xp: XP
-              amount: 10
+            - xp:
+                name: XP
+                amount: 10
         actions:
-            - xp: achievementActionXP 
-              amount: 1
+            - xp:
+                name: achievementActionXP
+                amount: 1

--- a/test/config/user_config.yml
+++ b/test/config/user_config.yml
@@ -6,11 +6,13 @@ achievements:
     TestAchievement:
         #add this so rule parsing works
         requirements:
-            - xp: XP
-              amount: 0
+            - xp:
+                name: XP
+                amount: 0
     HiddenAchievement:
         #add this so rule parsing works
         requirements:
-            - xp: XP
-              amount: 0
+            - xp:
+                name: XP
+                amount: 0
         hidden: true

--- a/test/config/xp-rule-checker-config.yml
+++ b/test/config/xp-rule-checker-config.yml
@@ -4,17 +4,21 @@ XPs:
 events:
     EventGiving10XP:
         actions:
-            - xp: XP
-              amount: 10 
+            - xp:
+                name: XP
+                amount: 10
     EventGiving25NonStandardXP:
         actions:
-            - xp: nonStandardXP
-              amount: 25
+            - xp:
+                name: nonStandardXP
+                amount: 25
     EventGivingMultipleKindsOfXP:
         actions:
-            - xp: XP
-              amount: 20
-            - xp: nonStandardXP
-              amount: 30
+            - xp:
+                name: XP
+                amount: 20
+            - xp:
+                name: nonStandardXP
+                amount: 30
 
 achievements: []


### PR DESCRIPTION
I always struggle when writing our yaml, so I changed the syntax a little. For now only with achievements:
``` 
achievement:
         name: XYZ
         amount: 1
```
instead of 
```
achievement: XYZ
        amount: 1
```

To be consistent, I'd also like to change that with xp requirements, but first wanted to hear your opinion on this.