### PR TITLE
Use `npm install` when running Greenkeeper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ cache:
   directories:
     - "$HOME/.npm"
 
-install:
-  - npm ci
+install: case $TRAVIS_BRANCH in greenkeeper*) npm i;; *) npm ci;; esac;
 
 before_install:
   - npm i -g npm@6.1.0


### PR DESCRIPTION
Greenkeeper incorrectly assumes upgrading a dependency failed in https://github.com/schul-cloud/gamification/issues/73#issuecomment-443544217. This is because we use `npm ci` to install dependencies on Travis, see here: https://github.com/greenkeeperio/greenkeeper-lockfile/issues/156

This PR conditionally uses `npm install` when building a Greenkeeper branch and should fix #73.